### PR TITLE
style: match axis label fonts and limit tick density

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,13 +229,16 @@
       doc.line(chartStartX, axisBottomY, chartStartX + barMaxWidth, axisBottomY);
 
       // Horizontal axis labels (whole numbers)
-      doc.setFont('helvetica', 'normal');
-      doc.setFontSize(10);
+      doc.setFont('helvetica', 'bold');
+      doc.setFontSize(nameFontSize);
       const maxWhole = Math.ceil(maxValue);
-      for (let i = 0; i <= maxWhole; i++) {
+      const maxLabels = 10;
+      const step = maxWhole > maxLabels ? Math.ceil(maxWhole / maxLabels) : 1;
+      const labelY = axisBottomY + nameFontSize + 5;
+      for (let i = 0; i <= maxWhole; i += step) {
         const xPos = chartStartX + (i / maxValue) * barMaxWidth;
         doc.line(xPos, axisBottomY - 3, xPos, axisBottomY + 3);
-        doc.text(String(i), xPos, axisBottomY + 15, { align: 'center' });
+        doc.text(String(i), xPos, labelY, { align: 'center' });
       }
 
       if (zeroes.length) {


### PR DESCRIPTION
## Summary
- make horizontal axis labels bold and match vertical axis font size
- limit the number of horizontal axis ticks to reduce crowding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c69ebf520c832fafc6a61e04f1f2f2